### PR TITLE
updated agent container startup command

### DIFF
--- a/terraform/aws/ecs/main.tf
+++ b/terraform/aws/ecs/main.tf
@@ -143,7 +143,7 @@ resource "aws_ecs_task_definition" "datagrail_agent" {
         "supervisord",
         "-n",
         "-c",
-        "/etc/supervisord.conf"
+        "/etc/rm.conf"
       ],
       environment = [
         { "name" = "DATAGRAIL_AGENT_CONFIG", "value" = file("config/datagrail-agent-config.json") }


### PR DESCRIPTION
When breaking out RDD and RM agent, the supervisord file names changed, and as a result, the startup commands for the container did as well. This change is to reflect the startup command change in the task definition in the ECS Terraform for the agent container.