### PR TITLE
[CUS-6568] Remove port mappings from RDD ECS task definition

### DIFF
--- a/terraform/request_manager/aws/ecs/main.tf
+++ b/terraform/request_manager/aws/ecs/main.tf
@@ -143,13 +143,6 @@ resource "aws_ecs_task_definition" "datagrail_agent" {
           "awslogs-stream-prefix" = "/ecs"
         }
       },
-      portMappings = [
-        {
-          "hostPort"      = 80
-          "protocol"      = "tcp"
-          "containerPort" = 80
-        }
-      ],
       command = [
         "supervisord",
         "-n",


### PR DESCRIPTION
Remove port mappings from the RDD ECS task definition